### PR TITLE
Update useTimer.js

### DIFF
--- a/src/useTimer.js
+++ b/src/useTimer.js
@@ -21,9 +21,9 @@ export default function useTimer({ expiryTimestamp: expiry, onExpire, autoStart 
   const [delay, setDelay] = useState(getDelayFromExpiryTimestamp(expiryTimestamp));
 
   function handleExpire() {
-    Validate.onExpire(onExpire) && onExpire();
     setIsRunning(false);
     setDelay(null);
+    Validate.onExpire(onExpire) && onExpire();
   }
 
   function pause() {


### PR DESCRIPTION
Changing order of operations on handle expiry to ensure that user provided expire method called after `setIsRunning` and `setDelay` are set. The use case this addresses is where you restart the timer in the user supplied onExpire method. This corrects the order of operations.